### PR TITLE
[IMP] Allow other database containers

### DIFF
--- a/templates/confluence/1/docker-compose.yml
+++ b/templates/confluence/1/docker-compose.yml
@@ -1,0 +1,77 @@
+---
+version: '2'
+
+volumes:
+  confluence-jre-security-data:
+    driver: ${VOLUME_DRIVER}
+  confluence-home-data:
+    driver: ${VOLUME_DRIVER}
+  confluence-install-data:
+    driver: ${VOLUME_DRIVER}
+  {{- if eq .Values.PSQL_SERVICE "" }}
+  confluence-db-data:
+    driver: ${VOLUME_DRIVER}
+  {{- end }}
+
+services:
+
+  confluence-server:
+    image: laslabs/alpine-confluence:6.6.0
+    volumes:
+    - confluence-home-data:/var/atlassian/confluence
+    - confluence-log-data:/opt/atlassian/confluence/logs
+    - confluence-jre-security-data:/usr/lib/jvm/java-1.8-openjdk/jre/lib/security
+    - confluence-install-conf-data:/opt/atlassian/confluence/conf
+    labels:
+      {{- if ne .Values.TRAEFIK_DOMAIN "" }}
+      traefik.domain: "${TRAEFIK_DOMAIN}"
+      {{- end }}
+      {{- if ne .Values.TRAEFIK_HOST "" }}
+      traefik.frontend.rule: 'Host: ${TRAEFIK_HOST}'
+      {{- end }}
+      traefik.enable: 'true'
+      traefik.port: '8090'
+      io.rancher.container.pull_image: always
+      traefik.frontend.passHostHeader: 'true'
+    {{- if ne .Values.PSQL_SERVICE "" }}
+    external_links:
+    - "${PSQL_SERVICE}:${PSQL_LINK}"
+    {{- end }}
+    {{- if eq .Values.PSQL_SERVICE "" }}
+    links:
+    - "postgresql:${PSQL_LINK}"
+    {{- end }}
+    scale: 1
+    start_on_create: true
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 8090
+      unhealthy_threshold: 60
+      initializing_timeout: 200000
+      interval: 2000
+      strategy: recreate
+      request_line: GET "/" "HTTP/1.0"
+      reinitializing_timeout: 200000
+
+  {{- if eq .Values.PSQL_SERVICE "" }}
+  postgresql:
+    image: postgres:9.6-alpine
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_PASSWORD: ${PSQL_PASSWORD}
+      POSTGRES_USER: ${PSQL_USER}
+    volumes:
+    - confluence-db-data:/var/lib/postgresql/data
+    scale: 1
+    start_on_create: true
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 5432
+      unhealthy_threshold: 20
+      initializing_timeout: 60000
+      interval: 5000
+      strategy: recreate
+      reinitializing_timeout: 60000
+  {{- end }}

--- a/templates/confluence/1/rancher-compose.yml
+++ b/templates/confluence/1/rancher-compose.yml
@@ -1,0 +1,62 @@
+version: "2"
+
+catalog:
+  name: Confluence
+  version: "v0.1.1"
+  description: |
+    Confluence with a PostgreSQL backend.
+    Meant to be proxied by Traefik.
+  uuid: laslabs-confluence-1
+  minimum_rancher_version: v1.0.0
+  questions:
+
+    - variable: "VOLUME_DRIVER"
+      description: "The volume driver to use for persistent storage."
+      label: "Volume Driver"
+      required: true
+      type: "enum"
+      default: "local"
+      options:
+        - local
+        - rancher-ebs
+        - rancher-efs
+        - rancher-nfs
+
+    - variable: "PSQL_SERVICE"
+      description: |
+        Existing PostgreSQL database service to use.
+        Leaving this empty will create a Postgres service in the stack.
+      label: "PostgreSQL Service"
+      type: "service"
+
+    - variable: "PSQL_LINK"
+      description: "Name of PostgreSQL server, as Confluence will see it."
+      label: "PostgreSQL Name"
+      default: "db"
+      type: "string"
+      required: true
+
+    - variable: "PSQL_USER"
+      description: "Username to use for the PostgreSQL server."
+      label: "PostgreSQL User"
+      default: "jira"
+      type: "string"
+      required: true
+
+    - variable: "PSQL_PASSWORD"
+      description: "Password to use for the PostgreSQL server."
+      label: "PostgreSQL Password"
+      type: "password"
+      required: true
+
+    - variable: "TRAEFIK_DOMAIN"
+      description: "Override for the base domain that is defined in Traefik."
+      label: "Traefik Domain"
+      type: "string"
+
+    - variable: "TRAEFIK_HOST"
+      description: |
+        Additional domain name that should be advertised through Traefik.
+        Comma separate to include more than one.
+      label: "Traefik Host"
+      type: "string"

--- a/templates/confluence/config.yml
+++ b/templates/confluence/config.yml
@@ -2,7 +2,7 @@ name: Confluence
 description: |
   Confluence based on Alpine with a PostgreSQL database. This build is meant to be
   behind a Traefik proxy.
-version: v0.1.0
+version: v0.1.1
 category: CMS
 maintainer: LasLabs Inc. <support@laslabs.com>
 license: Apache 2.0

--- a/templates/jira/1/docker-compose.yml
+++ b/templates/jira/1/docker-compose.yml
@@ -1,0 +1,76 @@
+---
+version: '2'
+volumes:
+  jira-jre-security-data:
+    driver: ${VOLUME_DRIVER}
+  jira-home-data:
+    driver: ${VOLUME_DRIVER}
+  jira-install-data:
+    driver: ${VOLUME_DRIVER}
+  {{- if eq .Values.PSQL_SERVICE "" }}
+  jira-db-data:
+    driver: ${VOLUME_DRIVER}
+  {{- end }}
+
+services:
+
+  jira-server:
+    image: laslabs/alpine-jira:7.6.2
+    volumes:
+    - jira-home-data:/var/atlassian/jira
+    - jira-log-data:/opt/atlassian/jira/logs
+    - jira-jre-security-data:/usr/lib/jvm/java-1.8-openjdk/jre/lib/security
+    - jira-install-conf-data:/opt/atlassian/jira/conf
+    labels:
+      {{- if ne .Values.TRAEFIK_DOMAIN "" }}
+      traefik.domain: "${TRAEFIK_DOMAIN}"
+      {{- end }}
+      {{- if ne .Values.TRAEFIK_HOST "" }}
+      traefik.frontend.rule: 'Host: ${TRAEFIK_HOST}'
+      {{- end }}
+      traefik.enable: 'true'
+      traefik.port: '8080'
+      io.rancher.container.pull_image: always
+      traefik.frontend.passHostHeader: 'true'
+    {{- if ne .Values.PSQL_SERVICE "" }}
+    external_links:
+    - "${PSQL_SERVICE}:${PSQL_LINK}"
+    {{- end }}
+    {{- if eq .Values.PSQL_SERVICE "" }}
+    links:
+    - "postgresql:${PSQL_LINK}"
+    {{- end }}
+    scale: 1
+    start_on_create: true
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 8080
+      unhealthy_threshold: 60
+      initializing_timeout: 200000
+      interval: 2000
+      strategy: recreate
+      request_line: GET "/" "HTTP/1.0"
+      reinitializing_timeout: 200000
+
+  {{- if eq .Values.PSQL_SERVICE "" }}
+  postgresql:
+    image: postgres:9.6-alpine
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_PASSWORD: ${PSQL_PASSWORD}
+      POSTGRES_USER: ${PSQL_USER}
+    volumes:
+    - jira-db-data:/var/lib/postgresql/data
+    scale: 1
+    start_on_create: true
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 5432
+      unhealthy_threshold: 20
+      initializing_timeout: 60000
+      interval: 5000
+      strategy: recreate
+      reinitializing_timeout: 60000
+  {{- end }}

--- a/templates/jira/1/rancher-compose.yml
+++ b/templates/jira/1/rancher-compose.yml
@@ -1,0 +1,62 @@
+version: "2"
+
+catalog:
+  name: JIRA
+  version: "v0.1.1"
+  description: |
+    JIRA with a PostgreSQL backend.
+    Meant to be proxied by Traefik.
+  uuid: laslabs-jira-1
+  minimum_rancher_version: v1.0.0
+  questions:
+
+    - variable: "VOLUME_DRIVER"
+      description: "The volume driver to use for persistent storage."
+      label: "Volume Driver"
+      required: true
+      type: "enum"
+      default: "local"
+      options:
+        - local
+        - rancher-ebs
+        - rancher-efs
+        - rancher-nfs
+
+    - variable: "PSQL_SERVICE"
+      description: |
+        Existing PostgreSQL database service to use.
+        Leaving this empty will create a Postgres service in the stack.
+      label: "PostgreSQL Service"
+      type: "service"
+
+    - variable: "PSQL_LINK"
+      description: "Name of PostgreSQL server, as Confluence will see it."
+      label: "PostgreSQL Name"
+      default: "db"
+      type: "string"
+      required: true
+
+    - variable: "PSQL_USER"
+      description: "Username to use for the PostgreSQL server."
+      label: "PostgreSQL User"
+      default: "jira"
+      type: "string"
+      required: true
+
+    - variable: "PSQL_PASSWORD"
+      description: "Password to use for the PostgreSQL server."
+      label: "PostgreSQL Password"
+      type: "password"
+      required: true
+
+    - variable: "TRAEFIK_DOMAIN"
+      description: "Override for the base domain that is defined in Traefik."
+      label: "Traefik Domain"
+      type: "string"
+
+    - variable: "TRAEFIK_HOST"
+      description: |
+        Additional domain name that should be advertised through Traefik.
+        Comma separate to include more than one.
+      label: "Traefik Host"
+      type: "string"

--- a/templates/jira/config.yml
+++ b/templates/jira/config.yml
@@ -2,7 +2,7 @@ name: JIRA
 description: |
   JIRA based on Alpine with a PostgreSQL database. This build is meant to be
   behind a Traefik proxy.
-version: v0.1.0
+version: v0.1.1
 category: Project Management
 maintainer: LasLabs Inc. <support@laslabs.com>
 license: Apache 2.0

--- a/templates/runbot/2/docker-compose.yml
+++ b/templates/runbot/2/docker-compose.yml
@@ -1,0 +1,240 @@
+---
+version: '2'
+
+volumes:
+  runbot-web-data:
+    driver: ${VOLUME_DRIVER}
+  runbot-build-data:
+    driver: ${VOLUME_DRIVER}
+  runbot-ssh-data:
+    driver: ${VOLUME_DRIVER}
+  runbot-private-addons:
+    driver: ${VOLUME_DRIVER}
+  {{- if eq .Values.PSQL_SERVICE "" }}
+  runbot-db-data:
+    driver: ${VOLUME_DRIVER}
+  {{- end }}
+
+services:
+
+  runbot-install:
+    image: laslabs/runbot:9.0
+    environment:
+      PGPASSWORD: "${PSQL_PASSWORD}"
+      PGUSER: "${PSQL_USER}"
+      WITHOUT_DEMO: "all"
+    command: 'install-addons'
+    {{- if ne .Values.PSQL_SERVICE "" }}
+    external_links:
+    - "${PSQL_SERVICE}:db"
+    {{- end }}
+    {{- if eq .Values.PSQL_SERVICE "" }}
+    links:
+    - postgresql:db
+    {{- end }}
+    volumes:
+    - runbot-web-data:/var/lib/odoo
+    - runbot-build-data:/opt/odoo/custom/src/odoo-extra/runbot/static
+    - runbot-private-addons:/opt/odoo/custom/src/private
+    tty: true
+    labels:
+      io.rancher.container.pull_image: 'always'
+      io.rancher.container.start_once: 'true'
+    scale: 1
+    start_on_create: true
+
+  runbot-web:
+    image: laslabs/runbot:9.0
+    environment:
+      ADMIN_PASSWORD: "${ODOO_ADMIN_PASSWORD}"
+      PGPASSWORD: "${PSQL_PASSWORD}"
+      PGUSER: "${PSQL_USER}"
+      PROXY_MODE: "true"
+      WAIT_NOHOST: runbot-install
+    volumes:
+    - runbot-web-data:/var/lib/odoo
+    - runbot-build-data:/opt/odoo/custom/src/odoo-extra/runbot/static
+    - runbot-private-addons:/opt/odoo/custom/src/private
+    tty: true
+    {{- if ne .Values.PSQL_SERVICE "" }}
+    external_links:
+    - "${PSQL_SERVICE}:db"
+    {{- end }}
+    {{- if eq .Values.PSQL_SERVICE "" }}
+    links:
+    - postgresql:db
+    {{- end }}
+    command:
+    - "/usr/local/bin/odoo"
+    - "--max-cron-threads=0"
+    - "--workers=${ODOO_WORKERS}"
+    labels:
+      {{- if ne .Values.TRAEFIK_DOMAIN "" }}
+      traefik.domain: "${TRAEFIK_DOMAIN}"
+      {{- end }}
+      {{- if ne .Values.TRAEFIK_HOST "" }}
+      traefik.frontend.rule: 'Host: ${TRAEFIK_HOST}'
+      {{- end }}
+      traefik.enable: 'true'
+      traefik.port: '8069'
+      io.rancher.container.hostname_override: container_name
+      io.rancher.container.pull_image: always
+      traefik.frontend.passHostHeader: 'true'
+      traefik.frontend.priority: 10
+    scale: 1
+    start_on_create: true
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 8069
+      unhealthy_threshold: 10
+      initializing_timeout: 60000
+      interval: 5000
+      strategy: recreate
+      request_line: GET "/" "HTTP/1.0"
+
+  runbot-cron:
+    privileged: true
+    image: laslabs/runbot:9.0
+    environment:
+      ADMIN_PASSWORD: "${ODOO_ADMIN_PASSWORD}"
+      PGPASSWORD: "${PSQL_PASSWORD}"
+      PGUSER: "${PSQL_USER}"
+      DOCKER_REGISTRY_DOCKERHUB_USERNAME: "${DOCKERHUB_USERNAME}"
+      DOCKER_REGISTRY_DOCKERHUB_PASSWORD: "${DOCKERHUB_PASSWORD}"
+      WAIT_NOHOST: runbot-install
+    volumes:
+    - runbot-web-data:/var/lib/odoo
+    - runbot-build-data:/opt/odoo/custom/src/odoo-extra/runbot/static
+    - runbot-ssh-data:/home/odoo/.ssh
+    - runbot-private-addons:/opt/odoo/custom/src/private
+    - /var/run/docker.sock:/var/run/docker.sock
+    tty: true
+    {{- if ne .Values.PSQL_SERVICE "" }}
+    external_links:
+    - "${PSQL_SERVICE}:db"
+    {{- end }}
+    {{- if eq .Values.PSQL_SERVICE "" }}
+    links:
+    - postgresql:db
+    {{- end }}
+    command:
+    - "/usr/local/bin/odoo"
+    - "--max-cron-threads=${ODOO_MAX_CRON_THREADS}"
+    - "--workers=0"
+    - "--limit-time-real=${ODOO_CRON_LIMIT_TIME_REAL}"
+    - "--limit-time-cpu=${ODOO_CRON_LIMIT_TIME_CPU}"
+    labels:
+      io.rancher.scheduler.affinity:host_label: "${HOST_LABEL_WORKER}"
+      io.rancher.container.hostname_override: container_name
+      io.rancher.container.pull_image: always
+    scale: 1
+    start_on_create: true
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 8069
+      unhealthy_threshold: 250
+      initializing_timeout: 60000
+      interval: 10000
+      strategy: recreate
+      request_line: GET "/" "HTTP/1.0"
+
+  runbot-longpolling:
+    image: laslabs/runbot:9.0
+    environment:
+      ADMIN_PASSWORD: "${ODOO_ADMIN_PASSWORD}"
+      PGPASSWORD: "${PSQL_PASSWORD}"
+      PGUSER: "${PSQL_USER}"
+      PROXY_MODE: "true"
+      WAIT_NOHOST: runbot-install
+    volumes:
+    - runbot-web-data:/var/lib/odoo
+    - runbot-build-data:/opt/odoo/custom/src/odoo-extra/runbot/static
+    - runbot-private-addons:/opt/odoo/custom/src/private
+    tty: true
+    {{- if ne .Values.PSQL_SERVICE "" }}
+    external_links:
+    - "${PSQL_SERVICE}:db"
+    {{- end }}
+    {{- if eq .Values.PSQL_SERVICE "" }}
+    links:
+    - postgresql:db
+    {{- end }}
+    command:
+    - "/usr/local/bin/odoo"
+    - "--max-cron-threads=0"
+    - "--workers=0"
+    labels:
+      {{- if ne .Values.TRAEFIK_HOST "" }}
+      traefik.frontend.rule: 'Host: ${TRAEFIK_HOST}; PathPrefix: /longpolling/;'
+      {{- else }}
+      traefik.frontend.rule: 'PathPrefix: /longpolling/;'
+      {{- end }}
+      traefik.domain: "${TRAEFIK_DOMAIN}"
+      traefik.enable: 'true'
+      traefik.port: '8069'
+      io.rancher.container.hostname_override: container_name
+      io.rancher.container.pull_image: always
+      traefik.frontend.passHostHeader: 'true'
+      traefik.frontend.priority: 10
+    scale: 1
+    start_on_create: true
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 8069
+      unhealthy_threshold: 10
+      initializing_timeout: 60000
+      interval: 5000
+      strategy: recreate
+      request_line: GET "/" "HTTP/1.0"
+
+  traefik:
+    image: laslabs/runbot-traefik:latest
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    command:
+    - --web
+    labels:
+      traefik.enable: 'true'
+      traefik.domain: "${TRAEFIK_DOMAIN}"
+      traefik.frontend.rule: 'HostRegexp: {subdomain:[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+}.${TRAEFIK_DOMAIN};'
+      traefik.port: '80'
+      io.rancher.container.pull_image: always
+      traefik.frontend.passHostHeader: 'true'
+      traefik.frontend.priority: 1
+    scale: 1
+    start_on_create: true
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 80
+      unhealthy_threshold: 10
+      initializing_timeout: 60000
+      interval: 5000
+      strategy: recreate
+      request_line: GET "/" "HTTP/1.0"
+
+  {{- if eq .Values.PSQL_SERVICE "" }}
+  postgresql:
+    image: postgres:9.6-alpine
+    hostname: db
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_PASSWORD: "${PSQL_PASSWORD}"
+      POSTGRES_USER: "${PSQL_USER}"
+    volumes:
+    - runbot-db-data:/var/lib/postgresql/data/
+    scale: 1
+    start_on_create: true
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 5432
+      unhealthy_threshold: 20
+      initializing_timeout: 60000
+      interval: 5000
+      strategy: recreate
+      reinitializing_timeout: 60000
+  {{- end }}

--- a/templates/runbot/2/rancher-compose.yml
+++ b/templates/runbot/2/rancher-compose.yml
@@ -1,0 +1,110 @@
+version: "2"
+
+catalog:
+  name: Odoo Runbot
+  version: "v9.0.0.1.1"
+  description: |
+    Runbot is a Continuous Integration server for Odoo.
+    Meant to be proxied by Traefik.
+  uuid: laslabs-runbot-1
+  minimum_rancher_version: v1.0.0
+  questions:
+
+    - variable: "VOLUME_DRIVER"
+      description: "The volume driver to use for persistent storage."
+      label: "Volume Driver"
+      required: true
+      type: "enum"
+      default: "local"
+      options:
+        - local
+        - rancher-ebs
+        - rancher-efs
+        - rancher-nfs
+
+    - variable: "PSQL_SERVICE"
+      description: |
+        Existing PostgreSQL database service to use.
+        Leaving this empty will create a Postgres service in the stack.
+      label: "PostgreSQL Service"
+      type: "service"
+
+    - variable: "PSQL_USER"
+      description: "Username to use for the PostgreSQL server."
+      label: "PostgreSQL User"
+      default: "odoo"
+      type: "string"
+      required: true
+
+    - variable: "PSQL_PASSWORD"
+      description: "Password to use for the PostgreSQL server."
+      label: "PostgreSQL Password"
+      type: "password"
+      required: true
+
+    - variable: "ODOO_ADMIN_PASSWORD"
+      description: "Password to Odoo database management interface."
+      label: "Odoo Admin Password"
+      type: "password"
+      required: true
+
+    - variable: "DOCKERHUB_USERNAME"
+      description: "Username to use when logging into DockerHub."
+      label: "DockerHub Username"
+      type: "string"
+
+    - variable: "DOCKERHUB_PASSWORD"
+      description: "Password to use when logging into DockerHub."
+      label: "DockerHub Password"
+      type: "password"
+
+    - variable: "ODOO_CRON_LIMIT_TIME_REAL"
+      description: "Real time limit for the Runbot workers."
+      label: "Odoo Worker Time Limit (Real)"
+      type: "int"
+      required: true
+      default: 6000
+
+    - variable: "ODOO_CRON_LIMIT_TIME_CPU"
+      description: "CPU time limit for the Runbot workers."
+      label: "Odoo Worker Time Limit (CPU)"
+      type: "int"
+      required: true
+      default: 600
+
+    - variable: "ODOO_WORKERS"
+      description: "Amount of workers allowed per web instance."
+      label: "Odoo Workers"
+      type: "int"
+      required: true
+      default: 4
+
+    - variable: "ODOO_MAX_CRON_THREADS"
+      description: "Maximum amount of threads allowed for crons (per cron instance)."
+      label: "Odoo Cron Threads"
+      type: "int"
+      required: true
+      default: 1
+
+    - variable: "HOST_LABEL_WORKER"
+      description: |
+        Host label and value that must be applied to any host that is allowed to have
+        a Runbot build worker.
+      label: "Worker Label"
+      type: "string"
+      required: true
+      default: "runbot_worker=true"
+
+    - variable: "TRAEFIK_DOMAIN"
+      description: "Base domain to define in Traefik."
+      label: "Traefik Domain"
+      type: "string"
+      required: true
+      default: rancher.internal
+
+    - variable: "TRAEFIK_HOST"
+      description: |
+        Additional domain name that should be advertised through Traefik.
+        Comma separate to include more than one.
+      label: "Traefik Host"
+      type: "string"

--- a/templates/runbot/config.yml
+++ b/templates/runbot/config.yml
@@ -2,7 +2,7 @@ name: Odoo Runbot
 description: |
   Runbot is a Continuous Integration server for Odoo.
   This build is meant to be behind a Traefik proxy.
-version: v9.0.0.1.0
+version: v9.0.0.1.1
 category: Continuous Integration
 maintainer: LasLabs Inc. <support@laslabs.com>
 license: Apache 2.0

--- a/templates/sentry/1/docker-compose.yml
+++ b/templates/sentry/1/docker-compose.yml
@@ -1,0 +1,199 @@
+version: '2'
+
+volumes:
+  sentry-filestore:
+    driver: ${VOLUME_DRIVER}
+  {{- if eq .Values.PSQL_SERVICE "" }}
+  sentry-db-data:
+    driver: ${VOLUME_DRIVER}
+  {{- end }}
+
+services:
+
+  sentry-server:
+    image: sentry:8.22
+    environment:
+      SENTRY_DB_NAME: "${PSQL_DB}"
+      SENTRY_DB_PASSWORD: "${PSQL_PASSWORD}"
+      SENTRY_DB_USER: "${PSQL_USER}"
+      SENTRY_EMAIL_HOST: "${SMTP_HOST}"
+      SENTRY_EMAIL_PASSWORD: "${SMTP_PASSWORD}"
+      SENTRY_EMAIL_PORT: "${SMTP_PORT}"
+      SENTRY_EMAIL_USER: "${SMTP_USER}"
+      SENTRY_POSTGRES_HOST: "postgresql"
+      SENTRY_SECRET_KEY: "${SENTRY_SECRET}"
+      SENTRY_SERVER_EMAIL: "${SENTRY_EMAIL}"
+    {{- if (or (ne .Values.PSQL_SERVICE "") (ne .Values.REDIS_SERVICE "") ) }}
+    external_links:
+    {{- end }}
+    {{- if ne .Values.PSQL_SERVICE ""}}
+    - "${PSQL_SERVICE}:postgresql"
+    {{- end }}
+    {{- if ne .Values.REDIS_SERVICE ""}}
+    - "${REDIS_SERVICE}:redis"
+    {{- end }}
+    {{- if (or (eq .Values.PSQL_SERVICE "") (eq .Values.REDIS_SERVICE "") ) }}
+    links:
+    {{- end }}
+    {{- if eq .Values.PSQL_SERVICE ""}}
+    - postgresql:postgresql
+    {{- end }}
+    {{- if eq .Values.REDIS_SERVICE ""}}
+    - redis:redis
+    {{- end }}
+    volumes:
+    - sentry-filestore:/var/lib/sentry/files
+    command:
+    - /bin/bash
+    - -c
+    - sentry upgrade --noinput && sentry createuser --email ${SENTRY_ADMIN_USER} --password ${SENTRY_ADMIN_PASSWORD} --superuser && /entrypoint.sh run web || /entrypoint.sh run web
+    labels:
+      {{- if ne .Values.TRAEFIK_DOMAIN "" }}
+      traefik.domain: "${TRAEFIK_DOMAIN}"
+      {{- end }}
+      {{- if ne .Values.TRAEFIK_HOST "" }}
+      traefik.frontend.rule: 'Host: ${TRAEFIK_HOST}'
+      {{- end }}
+      traefik.enable: 'true'
+      traefik.port: '9000'
+      traefik.frontend.passHostHeader: 'true'
+      io.rancher.container.hostname_override: container_name
+      io.rancher.container.pull_image: always
+    scale: 1
+    start_on_create: true
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 9000
+      unhealthy_threshold: 3
+      initializing_timeout: 600000
+      interval: 2000
+      strategy: recreate
+      request_line: GET "/auth/login/sentry" "HTTP/1.0"
+      reinitializing_timeout: 60000
+
+  sentry-cron:
+    image: sentry:8.22
+    environment:
+      SENTRY_DB_NAME: "${PSQL_DB}"
+      SENTRY_DB_PASSWORD: "${PSQL_PASSWORD}"
+      SENTRY_DB_USER: "${PSQL_USER}"
+      SENTRY_EMAIL_HOST: "${SMTP_HOST}"
+      SENTRY_EMAIL_PASSWORD: "${SMTP_PASSWORD}"
+      SENTRY_EMAIL_PORT: "${SMTP_PORT}"
+      SENTRY_EMAIL_USER: "${SMTP_USER}"
+      SENTRY_POSTGRES_HOST: "postgresql"
+      SENTRY_SECRET_KEY: "${SENTRY_SECRET}"
+      SENTRY_SERVER_EMAIL: "${SENTRY_EMAIL}"
+    {{- if (or (ne .Values.PSQL_SERVICE "") (ne .Values.REDIS_SERVICE "") ) }}
+    external_links:
+    {{- end }}
+    {{- if ne .Values.PSQL_SERVICE ""}}
+    - "${PSQL_SERVICE}:postgresql"
+    {{- end }}
+    {{- if ne .Values.REDIS_SERVICE ""}}
+    - "${REDIS_SERVICE}:redis"
+    {{- end }}
+    {{- if (or (eq .Values.PSQL_SERVICE "") (eq .Values.REDIS_SERVICE "") ) }}
+    links:
+    {{- end }}
+    {{- if eq .Values.PSQL_SERVICE ""}}
+    - postgresql:postgresql
+    {{- end }}
+    {{- if eq .Values.REDIS_SERVICE ""}}
+    - redis:redis
+    {{- end }}
+    volumes:
+    - sentry-filestore:/var/lib/sentry/files
+    command:
+    - run
+    - cron
+    labels:
+      io.rancher.container.hostname_override: container_name
+    scale: 1
+    start_on_create: true
+
+  sentry-worker:
+    image: sentry:8.22
+    environment:
+      SENTRY_DB_NAME: "${PSQL_DB}"
+      SENTRY_DB_PASSWORD: "${PSQL_PASSWORD}"
+      SENTRY_DB_USER: "${PSQL_USER}"
+      SENTRY_EMAIL_HOST: "${SMTP_HOST}"
+      SENTRY_EMAIL_PASSWORD: "${SMTP_PASSWORD}"
+      SENTRY_EMAIL_PORT: "${SMTP_PORT}"
+      SENTRY_EMAIL_USER: "${SMTP_USER}"
+      SENTRY_POSTGRES_HOST: "postgresql"
+      SENTRY_SECRET_KEY: "${SENTRY_SECRET}"
+      SENTRY_SERVER_EMAIL: "${SENTRY_EMAIL}"
+    {{- if (or (ne .Values.PSQL_SERVICE "") (ne .Values.REDIS_SERVICE "") ) }}
+    external_links:
+    {{- end }}
+    {{- if ne .Values.PSQL_SERVICE ""}}
+    - "${PSQL_SERVICE}:postgresql"
+    {{- end }}
+    {{- if ne .Values.REDIS_SERVICE ""}}
+    - "${REDIS_SERVICE}:redis"
+    {{- end }}
+    {{- if (or (eq .Values.PSQL_SERVICE "") (eq .Values.REDIS_SERVICE "") ) }}
+    links:
+    {{- end }}
+    {{- if eq .Values.PSQL_SERVICE ""}}
+    - postgresql:postgresql
+    {{- end }}
+    {{- if eq .Values.REDIS_SERVICE ""}}
+    - redis:redis
+    {{- end }}
+    command:
+    - run
+    - worker
+    volumes:
+    - sentry-filestore:/var/lib/sentry/files
+    labels:
+      io.rancher.scheduler.global: 'true'
+      io.rancher.container.hostname_override: container_name
+    scale: 1
+    start_on_create: true
+
+  {{- if eq .Values.REDIS_SERVICE ""}}
+  redis:
+    image: redis:4-alpine
+    labels:
+      io.rancher.container.hostname_override: container_name
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 6379
+      unhealthy_threshold: 3
+      initializing_timeout: 60000
+      interval: 2000
+      strategy: recreate
+      reinitializing_timeout: 60000
+    scale: 1
+    start_on_create: true
+  {{- end }}
+
+  {{- if eq .Values.PSQL_SERVICE ""}}
+  postgresql:
+    image: postgres:9.6-alpine
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_DB: ${PSQL_DB}
+      POSTGRES_PASSWORD: ${PSQL_PASSWORD}
+      POSTGRES_USER: ${PSQL_USER}
+    volumes:
+    - sentry-db-data:/var/lib/postgresql/data
+    labels:
+      io.rancher.container.hostname_override: container_name
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 5432
+      unhealthy_threshold: 3
+      initializing_timeout: 60000
+      interval: 2000
+      strategy: recreate
+      reinitializing_timeout: 60000
+    scale: 1
+    start_on_create: true
+  {{- end }}

--- a/templates/sentry/1/rancher-compose.yml
+++ b/templates/sentry/1/rancher-compose.yml
@@ -3,7 +3,9 @@ version: "2"
 catalog:
   name: Sentry
   version: "v0.1.1"
-  description: "Sentry with a PostgreSQL backend. Meant to be proxied by Traefik."
+  description: |
+    Sentry with a PostgreSQL backend.
+    Meant to be proxied by Traefik.
   uuid: laslabs-sentry-1
   minimum_rancher_version: v1.0.0
   questions:
@@ -21,14 +23,14 @@ catalog:
         - rancher-nfs
 
     - variable: "REDIS_SERVICE"
-      description: \
+      description: |
         Existing Redis service to use.
         Leaving this empty will create a Redis service in the stack.
       label: "Redis Service"
       type: "service"
 
     - variable: "PSQL_SERVICE"
-      description: \
+      description: |
         Existing PostgreSQL database service to use.
         Leaving this empty will create a Postgres service in the stack.
       label: "PostgreSQL Service"
@@ -53,7 +55,6 @@ catalog:
       label: "PostgreSQL Password"
       type: "password"
       required: true
-      default: password
 
     - variable: "SMTP_HOST"
       description: "Hostname to use for outbound emails."
@@ -86,7 +87,6 @@ catalog:
       label: "Sentry Secret"
       type: "password"
       required: true
-      default: password
 
     - variable: "TRAEFIK_DOMAIN"
       description: "Override for the base domain that is defined in Traefik."

--- a/templates/sentry/1/rancher-compose.yml
+++ b/templates/sentry/1/rancher-compose.yml
@@ -1,0 +1,99 @@
+version: "2"
+
+catalog:
+  name: Sentry
+  version: "v0.1.1"
+  description: "Sentry with a PostgreSQL backend. Meant to be proxied by Traefik."
+  uuid: laslabs-sentry-1
+  minimum_rancher_version: v1.0.0
+  questions:
+
+    - variable: "VOLUME_DRIVER"
+      description: "The volume driver to use for persistent storage."
+      label: "Volume Driver"
+      required: true
+      type: "enum"
+      default: "local"
+      options:
+        - local
+        - rancher-ebs
+        - rancher-efs
+        - rancher-nfs
+
+    - variable: "REDIS_SERVICE"
+      description: \
+        Existing Redis service to use.
+        Leaving this empty will create a Redis service in the stack.
+      label: "Redis Service"
+      type: "service"
+
+    - variable: "PSQL_SERVICE"
+      description: \
+        Existing PostgreSQL database service to use.
+        Leaving this empty will create a Postgres service in the stack.
+      label: "PostgreSQL Service"
+      type: "service"
+
+    - variable: "PSQL_DB"
+      description: "Name of the database on the PostgreSQL server."
+      label: "PostgreSQL Database"
+      default: "sentry"
+      type: "string"
+      required: true
+
+    - variable: "PSQL_USER"
+      description: "Username to use for the PostgreSQL server."
+      label: "PostgreSQL User"
+      default: "sentry"
+      type: "string"
+      required: true
+
+    - variable: "PSQL_PASSWORD"
+      description: "Password to use for the PostgreSQL server."
+      label: "PostgreSQL Password"
+      type: "password"
+      required: true
+      default: password
+
+    - variable: "SMTP_HOST"
+      description: "Hostname to use for outbound emails."
+      label: "SMTP Host"
+      type: "string"
+
+    - variable: "SMTP_PORT"
+      description: "Port number to use when connecting to SMTP server."
+      label: "SMTP Port"
+      type: "int"
+      default: "587"
+
+    - variable: "SMTP_USER"
+      description: "Username to use when logging in to SMTP server."
+      label: "SMTP User"
+      type: "string"
+
+    - variable: "SMTP_PASSWORD"
+      description: "Password to use when logging in to the SMTP server."
+      label: "SMTP Password"
+      type: "password"
+
+    - variable: "SENTRY_EMAIL"
+      description: "Email address that Sentry sends from."
+      label: "Sentry Email"
+      type: "string"
+
+    - variable: "SENTRY_SECRET"
+      description: "A secret key used for cryptographic functions within Sentry."
+      label: "Sentry Secret"
+      type: "password"
+      required: true
+      default: password
+
+    - variable: "TRAEFIK_DOMAIN"
+      description: "Override for the base domain that is defined in Traefik."
+      label: "Traefik Domain"
+      type: "string"
+
+    - variable: "TRAEFIK_HOST"
+      description: "Additional domain name that should be advertised through Traefik."
+      label: "Traefik Host"
+      type: "string"

--- a/templates/sentry/config.yml
+++ b/templates/sentry/config.yml
@@ -2,7 +2,7 @@ name: Sentry
 description: |
   Sentry error tracking system.
   This build is meant to be behind a Traefik proxy.
-version: v0.1.0
+version: v0.1.1
 category: CMS
 maintainer: LasLabs Inc. <support@laslabs.com>
 license: Apache 2.0


### PR DESCRIPTION
Create new version of all applications allowing for the definition of an external database container.

Resubmission of #6, which Github closed when I rebased and won't allow for a reopen. 